### PR TITLE
Send ETCD metrics to loggregator

### DIFF
--- a/cmd/etcd-metrics-server/main.go
+++ b/cmd/etcd-metrics-server/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cloudfoundry-incubator/cf-debug-server"
 	"github.com/cloudfoundry-incubator/cf-lager"
 	"github.com/cloudfoundry-incubator/cf_http"
-	"github.com/cloudfoundry-incubator/etcd-metrics-server/metrics_server"
+	"github.com/cloudfoundry-incubator/etcd-metrics-server/runners"
 	"github.com/cloudfoundry-incubator/metricz/collector_registrar"
 )
 
@@ -117,9 +117,9 @@ func main() {
 	}
 }
 
-func initializeServer(logger lager.Logger, natsClient diegonats.NATSClient) *metrics_server.MetricsServer {
+func initializeServer(logger lager.Logger, natsClient diegonats.NATSClient) *runners.MetricsServer {
 	registrar := collector_registrar.New(natsClient)
-	return metrics_server.New(registrar, logger, metrics_server.Config{
+	return runners.New(registrar, logger, runners.Config{
 		JobName: *jobName,
 		EtcdURL: &url.URL{
 			Scheme: *etcdScheme,

--- a/cmd/etcd-metrics-server/main.go
+++ b/cmd/etcd-metrics-server/main.go
@@ -147,7 +147,7 @@ func initializeMetronNotifier(logger lager.Logger) *runners.PeriodicMetronNotifi
 
 func initializeServer(logger lager.Logger, natsClient diegonats.NATSClient) *runners.MetricsServer {
 	registrar := collector_registrar.New(natsClient)
-	return runners.New(registrar, logger, runners.Config{
+	return runners.NewMetricsServer(registrar, logger, runners.Config{
 		JobName:  *jobName,
 		EtcdURL:  createEtcdURL(),
 		Port:     *port,

--- a/cmd/etcd-metrics-server/main_test.go
+++ b/cmd/etcd-metrics-server/main_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/apcera/nats"
 	"github.com/cloudfoundry/gunk/diegonats"
+	"github.com/cloudfoundry/gunk/diegonats/gnatsdrunner"
 	"github.com/cloudfoundry/storeadapter/storerunner/etcdstorerunner"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -25,8 +26,8 @@ var _ = Describe("Etcd Metrics Server", func() {
 	var session *gexec.Session
 
 	BeforeEach(func() {
-		gnatsdRunner, natsClient = diegonats.StartGnatsd(4222)
-		etcdRunner = etcdstorerunner.NewETCDClusterRunner(5001, 1)
+		gnatsdRunner, natsClient = gnatsdrunner.StartGnatsd(4222)
+		etcdRunner = etcdstorerunner.NewETCDClusterRunner(5001, 1, nil)
 		etcdRunner.Start()
 	})
 

--- a/instruments/leader.go
+++ b/instruments/leader.go
@@ -42,7 +42,7 @@ func (leader *Leader) Emit() instrumentation.Context {
 
 	resp, err := client.Get(leader.statsEndpoint)
 	if err != nil {
-		leader.logger.Error("failed-to-collect-stats", err)
+		leader.logger.Error("failed-to-collect-leader-stats", err)
 		return context
 	}
 
@@ -50,7 +50,7 @@ func (leader *Leader) Emit() instrumentation.Context {
 
 	err = json.NewDecoder(resp.Body).Decode(&stats)
 	if err != nil {
-		leader.logger.Error("failed-to-unmarshal-stats", err)
+		leader.logger.Error("failed-to-unmarshal-leader-stats", err)
 		return context
 	}
 

--- a/instruments/server.go
+++ b/instruments/server.go
@@ -45,7 +45,7 @@ func (server *Server) Emit() instrumentation.Context {
 	}
 
 	isLeader := 0
-	if stats.State == "leader" {
+	if stats.State == "StateLeader" {
 		isLeader = 1
 	}
 

--- a/instruments/server.go
+++ b/instruments/server.go
@@ -32,7 +32,7 @@ func (server *Server) Emit() instrumentation.Context {
 
 	resp, err := http.Get(server.statsEndpoint)
 	if err != nil {
-		server.logger.Error("failed-to-collect-stats", err)
+		server.logger.Error("failed-to-collect-self-stats", err)
 		return context
 	}
 
@@ -40,7 +40,7 @@ func (server *Server) Emit() instrumentation.Context {
 
 	err = json.NewDecoder(resp.Body).Decode(&stats)
 	if err != nil {
-		server.logger.Error("failed-to-unmarshal-stats", err)
+		server.logger.Error("failed-to-unmarshal-self-stats", err)
 		return context
 	}
 

--- a/instruments/server_test.go
+++ b/instruments/server_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Server Instrumentation", func() {
 				ghttp.RespondWith(200, `
                     {
                         "name": "node1",
-                        "state": "leader",
+                        "state": "StateLeader",
 
                         "leaderInfo": {
                             "name": "node1",

--- a/instruments/store.go
+++ b/instruments/store.go
@@ -36,7 +36,7 @@ func (store *Store) Emit() instrumentation.Context {
 
 	statsResp, err := http.Get(store.statsEndpoint)
 	if err != nil {
-		store.logger.Error("failed-to-collect-stats", err)
+		store.logger.Error("failed-to-collect-store-stats", err)
 		return context
 	}
 
@@ -44,7 +44,7 @@ func (store *Store) Emit() instrumentation.Context {
 
 	err = json.NewDecoder(statsResp.Body).Decode(&stats)
 	if err != nil {
-		store.logger.Error("failed-to-unmarshal-stats", err)
+		store.logger.Error("failed-to-unmarshal-store-stats", err)
 		return context
 	}
 

--- a/runners/metrics_server.go
+++ b/runners/metrics_server.go
@@ -1,4 +1,4 @@
-package metrics_server
+package runners
 
 import (
 	"net/url"

--- a/runners/metrics_server.go
+++ b/runners/metrics_server.go
@@ -31,7 +31,7 @@ type Config struct {
 	Password string
 }
 
-func New(registrar collector_registrar.CollectorRegistrar, logger lager.Logger, config Config) *MetricsServer {
+func NewMetricsServer(registrar collector_registrar.CollectorRegistrar, logger lager.Logger, config Config) *MetricsServer {
 	return &MetricsServer{
 		registrar: registrar,
 		logger:    logger,

--- a/runners/periodic_metron_notifier.go
+++ b/runners/periodic_metron_notifier.go
@@ -1,0 +1,79 @@
+package runners
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"time"
+
+	"github.com/cloudfoundry-incubator/etcd-metrics-server/instruments"
+	"github.com/cloudfoundry-incubator/metricz/instrumentation"
+	"github.com/cloudfoundry/dropsonde/metrics"
+	"github.com/pivotal-golang/lager"
+)
+
+type PeriodicMetronNotifier struct {
+	etcdURL  string
+	logger   lager.Logger
+	interval time.Duration
+}
+
+func NewPeriodicMetronNotifier(
+	etcdURL string,
+	logger lager.Logger,
+	interval time.Duration,
+) *PeriodicMetronNotifier {
+
+	return &PeriodicMetronNotifier{etcdURL, logger, interval}
+}
+
+func convertToFloat64(value interface{}) float64 {
+	switch v := value.(type) {
+	case float64:
+		return v
+	case uint64:
+		return float64(v)
+	case int:
+		return float64(v)
+	default:
+		msg := fmt.Sprintf("invalid type %v", reflect.TypeOf(value).Name())
+		panic(msg)
+	}
+}
+
+func sendMetrics(instrument instrumentation.Instrumentable) {
+	context := instrument.Emit()
+	for _, metric := range context.Metrics {
+		value := convertToFloat64(metric.Value)
+		unit := GetMetricUnit(metric.Name)
+		metrics.SendValue(metric.Name, value, unit)
+	}
+}
+
+func (n *PeriodicMetronNotifier) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	instruments := []instrumentation.Instrumentable{
+		instruments.NewLeader(n.etcdURL, n.logger),
+		instruments.NewServer(n.etcdURL, n.logger),
+		instruments.NewStore(n.etcdURL, n.logger),
+	}
+
+	ticker := time.NewTicker(n.interval)
+	defer ticker.Stop()
+
+	close(ready)
+
+	for {
+		select {
+		case <-ticker.C:
+
+			for _, instrument := range instruments {
+				sendMetrics(instrument)
+			}
+
+		case <-signals:
+			return nil
+		}
+	}
+
+	return nil
+}

--- a/runners/periodic_metron_notifier_test.go
+++ b/runners/periodic_metron_notifier_test.go
@@ -1,0 +1,249 @@
+package runners_test
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/cloudfoundry-incubator/etcd-metrics-server/runners"
+	"github.com/cloudfoundry/dropsonde/metric_sender/fake"
+	"github.com/cloudfoundry/dropsonde/metrics"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/pivotal-golang/lager/lagertest"
+	"github.com/tedsuo/ifrit"
+)
+
+// a bit of grace time for eventuallys
+const aBit = 50 * time.Millisecond
+
+var _ = Describe("PeriodicMetronNotifier", func() {
+	var (
+		leader   *ghttp.Server
+		follower *ghttp.Server
+
+		logger = lagertest.NewTestLogger("test")
+		sender *fake.FakeMetricSender
+
+		etcdURL        string
+		reportInterval time.Duration
+
+		metronNotifier ifrit.Process
+	)
+
+	BeforeEach(func() {
+		leader = ghttp.NewServer()
+		follower = ghttp.NewServer()
+
+		keyHandler := func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Etcd-Index", "3")
+			w.Header().Set("X-Raft-Index", "2")
+			w.Header().Set("X-Raft-Term", "1")
+		}
+
+		leader.RouteToHandler("GET", "/v2/stats/leader", ghttp.RespondWith(200, fixtureLeaderStats))
+		leader.RouteToHandler("GET", "/v2/stats/self", ghttp.RespondWith(200, fixtureSelfLeaderStats))
+		leader.RouteToHandler("GET", "/v2/stats/store", ghttp.RespondWith(200, fixtureStoreStats))
+		leader.RouteToHandler("GET", "/v2/keys/", keyHandler)
+
+		follower.RouteToHandler("GET", "/v2/stats/leader", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, leader.URL(), 302)
+		})
+
+		follower.RouteToHandler("GET", "/v2/stats/self", ghttp.RespondWith(200, fixtureSelfFollowerStats))
+		follower.RouteToHandler("GET", "/v2/stats/store", ghttp.RespondWith(200, fixtureStoreStats))
+		follower.RouteToHandler("GET", "/v2/keys/", keyHandler)
+
+		reportInterval = 100 * time.Millisecond
+		sender = fake.NewFakeMetricSender()
+		metrics.Initialize(sender, nil)
+	})
+
+	JustBeforeEach(func() {
+		metronNotifier = ifrit.Invoke(runners.NewPeriodicMetronNotifier(
+			etcdURL,
+			logger,
+			reportInterval,
+		))
+	})
+
+	AfterEach(func() {
+		metronNotifier.Signal(os.Interrupt)
+		Eventually(metronNotifier.Wait(), 2*time.Second).Should(Receive())
+
+		leader.Close()
+		follower.Close()
+	})
+
+	Context("when the report interval elapses", func() {
+		var metricEmitted = func(name string, value float64, unit string) {
+			Eventually(func() fake.Metric {
+				return sender.GetValue(name)
+			}).Should(Equal(fake.Metric{
+				Value: value,
+				Unit:  unit,
+			}), fmt.Sprintf("failed to get metric %s", name))
+		}
+
+		var metricNotEmitted = func(name string) {
+			Consistently(func() fake.Metric {
+				return sender.GetValue(name)
+			}).Should(Equal(fake.Metric{}))
+		}
+
+		var itShouldEmitStoreResults = func() {
+			metricEmitted("CompareAndDeleteFail", 0, runners.MetricUnit)
+			metricEmitted("CompareAndDeleteSuccess", 4, runners.MetricUnit)
+			metricEmitted("CompareAndSwapFail", 22, runners.MetricUnit)
+			metricEmitted("CompareAndSwapSuccess", 50350, runners.MetricUnit)
+			metricEmitted("CreateFail", 15252, runners.MetricUnit)
+			metricEmitted("CreateSuccess", 18, runners.MetricUnit)
+			metricEmitted("DeleteFail", 0, runners.MetricUnit)
+			metricEmitted("DeleteSuccess", 0, runners.MetricUnit)
+			metricEmitted("ExpireCount", 1, runners.MetricUnit)
+			metricEmitted("GetsFail", 26705, runners.MetricUnit)
+			metricEmitted("GetsSuccess", 10195, runners.MetricUnit)
+			metricEmitted("SetsFail", 0, runners.MetricUnit)
+			metricEmitted("SetsSuccess", 2540, runners.MetricUnit)
+			metricEmitted("UpdateFail", 0, runners.MetricUnit)
+			metricEmitted("UpdateSuccess", 0, runners.MetricUnit)
+			metricEmitted("Watchers", 12, runners.MetricUnit)
+			metricEmitted("EtcdIndex", 3, runners.MetricUnit)
+			metricEmitted("RaftIndex", 2, runners.MetricUnit)
+			metricEmitted("RaftTerm", 1, runners.MetricUnit)
+		}
+
+		Context("when the etcd node is a follower", func() {
+			BeforeEach(func() {
+				etcdURL = follower.URL()
+			})
+
+			It("should emit store statistics", func() {
+				itShouldEmitStoreResults()
+			})
+
+			It("should emit self (follower) statistics", func() {
+				metricEmitted("IsLeader", 0, runners.MetricUnit)
+				metricEmitted("SentAppendRequests", 4321, runners.MetricUnit)
+				metricEmitted("ReceivedAppendRequests", 1234, runners.MetricUnit)
+				metricEmitted("ReceivingRequestRate", 2.0, runners.RequestsPerSecondUnit)
+				metricEmitted("ReceivingBandwidthRate", 1.2, runners.BytesPerSecondUnit)
+			})
+
+			It("should not emit leader statistics", func() {
+				metricNotEmitted("Followers")
+				metricNotEmitted("Latency")
+			})
+		})
+
+		Context("when the etcd node is a leader", func() {
+			BeforeEach(func() {
+				etcdURL = leader.URL()
+			})
+
+			It("should emit store statistics", func() {
+				itShouldEmitStoreResults()
+			})
+
+			It("should emit self (leader) statistics", func() {
+				metricEmitted("IsLeader", 1, runners.MetricUnit)
+				metricEmitted("SentAppendRequests", 4321, runners.MetricUnit)
+				metricEmitted("ReceivedAppendRequests", 1234, runners.MetricUnit)
+				metricEmitted("SendingRequestRate", 5.0, runners.RequestsPerSecondUnit)
+				metricEmitted("SendingBandwidthRate", 3.0, runners.BytesPerSecondUnit)
+			})
+
+			It("should emit leader statistics", func() {
+				metricEmitted("Followers", 1, runners.MetricUnit)
+				metricEmitted("Latency", 0.153507, runners.MetricUnit)
+
+				// We wanted to test multiple followers and ensure that
+				// multiple latencies were reported. But due to limitations of
+				// the dropsonde protocol not accepting tags, the fake metrics
+				// server cannot distinguish multiple latency metrics.
+			})
+		})
+	})
+})
+
+var fixtureSelfFollowerStats = `
+{
+  "name": "node1",
+				"id": "node1-id",
+  "state": "StateFollower",
+
+  "leaderInfo": {
+	"leader": "node2-id",
+					"uptime": "17h41m45.103057785s",
+				  "startTime": "2015-02-13T01:28:26.657389108Z"
+  },
+
+  "recvAppendRequestCnt": 1234,
+  "recvPkgRate": 2.0,
+  "recvBandwidthRate": 1.2,
+
+  "sendAppendRequestCnt": 4321
+}`
+
+var fixtureSelfLeaderStats = `
+{
+  "name": "node2",
+				"id": "node2-id",
+  "state": "StateLeader",
+
+  "leaderInfo": {
+	"leader": "node2-id",
+					"uptime": "17h41m45.103057785s",
+				  "startTime": "2015-02-13T01:28:26.657389108Z"
+  },
+
+  "recvAppendRequestCnt": 1234,
+
+  "sendAppendRequestCnt": 4321,
+  "sendPkgRate": 5.0,
+  "sendBandwidthRate": 3.0
+}`
+
+var fixtureLeaderStats = `
+{
+  "leader": "node2-id",
+  "followers": {
+	"node1-id": {
+	  "latency": {
+		"current": 0.153507,
+		"average": 0.14636559394884047,
+		"standardDeviation": 0.15477392607571758,
+		"minimum": 8.4e-05,
+		"maximum": 6.78157
+	  },
+	  "counts": {
+		"fail": 4,
+		"success": 215000
+	  }
+	}
+  }
+}
+`
+
+var fixtureStoreStats = `
+{
+	"getsSuccess": 10195,
+	"getsFail": 26705,
+	"setsSuccess": 2540,
+	"setsFail": 0,
+	"deleteSuccess": 0,
+	"deleteFail": 0,
+	"updateSuccess": 0,
+	"updateFail": 0,
+	"createSuccess": 18,
+	"createFail": 15252,
+	"compareAndSwapSuccess": 50350,
+	"compareAndSwapFail": 22,
+	"compareAndDeleteSuccess": 4,
+	"compareAndDeleteFail": 0,
+	"expireCount": 1,
+	"watchers": 12
+}
+`

--- a/runners/runners_suite_test.go
+++ b/runners/runners_suite_test.go
@@ -1,0 +1,13 @@
+package runners_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Runner Suites")
+}

--- a/runners/units.go
+++ b/runners/units.go
@@ -1,0 +1,26 @@
+package runners
+
+const (
+	MetricUnit            = "Metric"
+	BytesPerSecondUnit    = "B/s"
+	RequestsPerSecondUnit = "Req/s"
+)
+
+var (
+	unitMap = map[string]string{
+		"SendingRequestRate":     RequestsPerSecondUnit,
+		"SendingBandwidthRate":   BytesPerSecondUnit,
+		"ReceivingRequestRate":   RequestsPerSecondUnit,
+		"ReceivingBandwidthRate": BytesPerSecondUnit,
+	}
+)
+
+func GetMetricUnit(metric string) string {
+	unit, ok := unitMap[metric]
+
+	if !ok {
+		return MetricUnit
+	} else {
+		return unit
+	}
+}


### PR DESCRIPTION
This change creates a periodic-metron-notifier which sends ETCD metrics at the specified interval.

In addition:
- we fixed the unit tests to work with updated dependency versions
- handle changes to etcd self stats response (leader => StateLeader)
- metrics are namespaced using the jobName flag